### PR TITLE
test: Adding `pip` to environment.

### DIFF
--- a/test/environment.yml
+++ b/test/environment.yml
@@ -3,5 +3,6 @@ channels:
   - symbiflow
 dependencies:
   - python
+  - pip
   - pip:
     - -r file:requirements.txt


### PR DESCRIPTION
Should fix;
```
Warning: you have pip-installed dependencies in your environment file,
but you do not list pip itself as one of your conda dependencies.  Conda
may not use the correct pip to install your packages, and they may end
up in the wrong place.  Please add an explicit pip dependency.  I'm
adding one for you, but still nagging you.
```

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>