### PR TITLE
Use double-colon for common targets (dist-clean, clean, env).

### DIFF
--- a/conda.mk
+++ b/conda.mk
@@ -128,7 +128,7 @@ $(CONDA_ENV_PYTHON): $(ENVIRONMENT_FILE) $(REQUIREMENTS_FILE) | $(CONDA_PYTHON) 
 	$(IN_CONDA_ENV_BASE) conda env update --name $(CONDA_ENV_NAME) --file $(ENVIRONMENT_FILE)
 	$(TOUCH) "$(CONDA_ENV_PYTHON)"
 
-env: $(CONDA_ENV_PYTHON)
+env:: $(CONDA_ENV_PYTHON)
 	$(IN_CONDA_ENV) conda info
 
 .PHONY: env
@@ -138,12 +138,12 @@ enter: $(CONDA_ENV_PYTHON)
 
 .PHONY: enter
 
-clean:
+clean::
 	rm -rf $(CONDA_DIR)
 
 .PHONY: clean
 
-dist-clean:
+dist-clean::
 	rm -rf $(ENV_DIR)
 
 .PHONY: dist-clean


### PR DESCRIPTION
Using a double-colon allows Makefiles using this one to add steps to these
common targets, rather than overwrite them.
