### PR TITLE
Improve isolation from system Python.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,18 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Make env
+    - name: make env
       run: |
         cd test
         make env
         make env-info
+
+    - name: example
+      run: |
+        cd test
+        make example-command
+
+    - name: test
+      run: |
+        cd test
+        make test-command

--- a/Makefile.template
+++ b/Makefile.template
@@ -26,4 +26,4 @@ example-command: | $(CONDA_ENV_PYTHON)
 
 # Check that no system packages are found in the environment.
 test-command: | $(CONDA_ENV_PYTHON)
-	$(IN_CONDA_ENV) python -c "import sys; assert all('/usr' not in p for p in sys.path), sys.path; print(sys.path)"
+	$(IN_CONDA_ENV) python check.py

--- a/Makefile.template
+++ b/Makefile.template
@@ -20,6 +20,10 @@ ENVIRONMENT_FILE := environment.yml
 include third_party/make-env/conda.mk
 
 # Example make target which runs commands inside the conda environment.
-test-command: | $(CONDA_ENV_PYTHON)
+example-command: | $(CONDA_ENV_PYTHON)
 	$(IN_CONDA_ENV) echo "Python is $$(which python)"
 	$(IN_CONDA_ENV) python --version
+
+# Check that no system packages are found in the environment.
+test-command: | $(CONDA_ENV_PYTHON)
+	$(IN_CONDA_ENV) python -c "import sys; assert all('/usr' not in p for p in sys.path), sys.path; print(sys.path)"

--- a/conda.mk
+++ b/conda.mk
@@ -66,6 +66,7 @@ DOWNLOADS_DIR     := $(ENV_DIR)$(SEP)downloads
 
 CONDA_INSTALLER   := Miniconda3-latest-$(OS_TYPE)-$(CPU_TYPE).$(OS_EXT)
 CONDA_PYTHON      := $(CONDA_DIR)$(SEP)$(PYTHON_BIN)
+CONDA_PYVENV      := $(CONDA_DIR)$(SEP)pyvenv.cfg
 CONDA_PKGS_DIR    := $(DOWNLOADS_DIR)$(SEP)conda-pkgs
 CONDA_PKGS_DEP    := $(CONDA_PKGS_DIR)$(SEP)urls.txt
 
@@ -78,6 +79,10 @@ CONDA_INSTALLER_DOWNLOAD := $(DOWNLOADS_DIR)$(SEP)$(CONDA_INSTALLER)
 
 CONDA_ALWAYS_YES  := 1
 export CONDA_ALWAYS_YES
+
+# Force ignoring a user's Python site.py config.
+PYTHONNOUSERSITE  := 1
+export PYTHONNOUSERSITE
 
 # Check spaces are not found in important locations
 NULL_STRING :=
@@ -120,11 +125,14 @@ $(CONDA_PYTHON): $(CONDA_INSTALLER_DOWNLOAD)
 	$(TOUCH) "$(CONDA_PYTHON)"
 endif
 
+$(CONDA_PYVENV): $(CONDA_PYTHON) $(MAKE_DIR)/conda.mk
+	echo "include-system-site-packages=false" >> $(CONDA_PYVENV)
+
 $(CONDA_ENVS_DIR): $(CONDA_PYTHON)
 	$(IN_CONDA_ENV_BASE) conda config --system --add envs_dirs $(CONDA_ENVS_DIR)
 	$(MKDIR) "$(CONDA_ENVS_DIR)"
 
-$(CONDA_ENV_PYTHON): $(ENVIRONMENT_FILE) $(REQUIREMENTS_FILE) | $(CONDA_PYTHON) $(CONDA_PKGS_DEP) $(CONDA_ENVS_DIR)
+$(CONDA_ENV_PYTHON): $(ENVIRONMENT_FILE) $(REQUIREMENTS_FILE) | $(CONDA_PYTHON) $(CONDA_PKGS_DEP) $(CONDA_ENVS_DIR) $(CONDA_PYVENV)
 	$(IN_CONDA_ENV_BASE) conda env update --name $(CONDA_ENV_NAME) --file $(ENVIRONMENT_FILE)
 	$(TOUCH) "$(CONDA_ENV_PYTHON)"
 

--- a/conda.mk
+++ b/conda.mk
@@ -125,8 +125,13 @@ $(CONDA_PYTHON): $(CONDA_INSTALLER_DOWNLOAD)
 	$(TOUCH) "$(CONDA_PYTHON)"
 endif
 
+# FIXME: Why does this break on Windows?
+ifeq ($(OS_TYPE),Windows)
+CONDA_PYVENV := $(CONDA_PYTHON)
+else
 $(CONDA_PYVENV): $(CONDA_PYTHON) $(MAKE_DIR)/conda.mk
 	echo "include-system-site-packages=false" >> $(CONDA_PYVENV)
+endif
 
 $(CONDA_ENVS_DIR): $(CONDA_PYTHON)
 	$(IN_CONDA_ENV_BASE) conda config --system --add envs_dirs $(CONDA_ENVS_DIR)

--- a/test/check.py
+++ b/test/check.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+# Check that no system packages are found in the environment.
+import sys
+assert all('/usr' not in p for p in sys.path), sys.path
+print(sys.path)


### PR DESCRIPTION
 * Exclude a users `site.py` using `PYTHONNOUSERSITE`.
 * Create a pyvenv.cfg file to exclude system-site-packages.

See [this stackoverflow post for more information](https://stackoverflow.com/questions/51525072/global-pip-referenced-within-a-conda-environment).

Issue was discovered by @whitequark and reported in https://github.com/QuickLogic-Corp/quicklogic-fpga-toolchain/issues/5#issuecomment-723464697