### PR TITLE
ci: add container jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
 
+
   test:
     strategy:
       fail-fast: false
@@ -36,18 +37,173 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: make env
+    - name: Make env
       run: |
         cd test
         make env
         make env-info
 
-    - name: example
+    - name: Make example-command
       run: |
         cd test
         make example-command
 
-    - name: test
+    - name: Make test-command
+      run: |
+        cd test
+        make test-command
+
+
+# https://www.debian.org/releases/
+# http://releases.ubuntu.com/
+  debian:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os:
+          - debian:buster
+          - debian:bullseye
+          - debian:sid
+          - ubuntu:14.04
+          - ubuntu:16.04
+          - ubuntu:18.04
+          - ubuntu:20.04
+          - ubuntu:20.10
+    container: ${{ matrix.os }}
+    steps:
+
+    - name: Install dependencies
+      run: |
+        apt update -qq
+        apt install -y make wget git
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Make env
+      run: |
+        cd test
+        make env
+        make env-info
+
+    - name: Make example-command
+      run: |
+        cd test
+        make example-command
+
+    - name: Make test-command
+      run: |
+        cd test
+        make test-command
+
+
+# https://fedoraproject.org/wiki/Releases
+  fedora:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os:
+          - 32
+          - 33
+          - 34
+    container: fedora:${{ matrix.os }}
+    steps:
+
+    - name: Install dependencies
+      run: |
+        dnf update -y
+        dnf install -y make wget git which
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Make env
+      run: |
+        cd test
+        make env
+        make env-info
+
+    - name: Make example-command
+      run: |
+        cd test
+        make example-command
+
+    - name: Make test-command
+      run: |
+        cd test
+        make test-command
+
+
+  centos:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        os:
+          - 7
+          - 8
+    container: centos:${{ matrix.os }}
+    steps:
+
+    - name: Install dependencies
+      run: |
+        yum update -y
+        yum install -y make wget git which
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Make env
+      run: |
+        cd test
+        make env
+        make env-info
+
+    - name: Make example-command
+      run: |
+        cd test
+        make example-command
+
+    - name: Make test-command
+      run: |
+        cd test
+        make test-command
+
+
+  archlinux:
+    runs-on: ubuntu-latest
+    container: archlinux
+    steps:
+
+    - name: Install dependencies
+      run: |
+        pacman -Syu --noconfirm
+        pacman -S make wget git which --noconfirm
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Make env
+      run: |
+        cd test
+        make env
+        make env-info
+
+    - name: Make example-command
+      run: |
+        cd test
+        make example-command
+
+    - name: Make test-command
       run: |
         cd test
         make test-command

--- a/Makefile.template
+++ b/Makefile.template
@@ -21,7 +21,9 @@ include third_party/make-env/conda.mk
 
 # Example make target which runs commands inside the conda environment.
 example-command: | $(CONDA_ENV_PYTHON)
-	$(IN_CONDA_ENV) echo "Python is $$(which python)"
+ifneq ($(OS_TYPE),Windows)
+	$(IN_CONDA_ENV) PYBIN=$$(which python3) && echo "Python is $$PYBIN"
+endif
 	$(IN_CONDA_ENV) python --version
 
 # Check that no system packages are found in the environment.


### PR DESCRIPTION
As discussed in #20, the following container based jobs are added to CI:

- Debian buster, bullseye and sid
- Ubuntu 14.04, 16.04, 18.04, 20.04 and 20.10
- Fedora 32, 33 and 34
- CentOS 7 and 8
- Arch Linux

In all cases, `make`, `wget` and `git` are installed using the corresponding package manager: `apt`, `dnf`, `yum` or `pacman`.

Some "older" distros seem not to find `.git`: Ubuntu 14.04, 16.04 and 18.04; and CentOS 7.