### PR TITLE
Remove output spam from Makefile.

### DIFF
--- a/conda.mk
+++ b/conda.mk
@@ -57,8 +57,6 @@ endif
 
 CONDA_ENV_NAME    := $(strip $(patsubst name:%,,$(CONDA_ENV_NAME_LINE)))
 
-$(info '$(CONDA_ENV_NAME_LINE)' '$(CONDA_ENV_NAME)')
-
 # Read the conda environment name from the environment.yml file.
 ENV_DIR           := $(TOP_DIR)$(SEP)env
 CONDA_DIR         := $(ENV_DIR)$(SEP)conda

--- a/os.mk
+++ b/os.mk
@@ -93,5 +93,3 @@ TOUCH := touch
 MKDIR := mkdir -p
 WGET  := wget
 endif
-
-$(info OS_TYPE=$(OS_TYPE) CPU_TYPE=$(CPU_TYPE))


### PR DESCRIPTION
Some debugging information was left in `conda.mk` and `os.mk` which caused make outputs to spam information.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>