### PR TITLE
Remove `file:` prefix in `environment.yml` file.

### DIFF
--- a/test/environment.yml
+++ b/test/environment.yml
@@ -5,4 +5,4 @@ dependencies:
   - python
   - pip
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
See following URL:
https://stackoverflow.com/questions/68571543/using-a-pip-requirements-file-in-a-conda-yml-file-throws-attributeerror-fileno/68586065#68586065

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>