### PR TITLE
Updating the CentOS distros.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,7 @@ jobs:
           - 7
           - stream8
           - stream9
-    container: centos:${{ matrix.os }}
+    container: quay.io/centos/centos:${{ matrix.os }}
     steps:
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,8 @@ jobs:
         cd test
         make test-command
 
-
+# https://en.wikipedia.org/wiki/CentOS#CentOS_releases
+# https://www.centos.org/centos-stream/
   centos:
     runs-on: ubuntu-latest
     strategy:
@@ -153,7 +154,8 @@ jobs:
       matrix:
         os:
           - 7
-          - 8
+          - stream8
+          - stream9
     container: centos:${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
 * Removing the EOL CentOS `6` and `8`.
 * Adding the CentOS Stream `8` and `9`.

Fixes #34.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>