### PR TITLE
Update Fedora based distros.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,9 +113,10 @@ jobs:
       max-parallel: 3
       matrix:
         os:
-          - 32
-          - 33
-          - 34
+          - 36
+          - 37
+          - 38
+          - rawhide
     container: fedora:${{ matrix.os }}
     steps:
 


### PR DESCRIPTION
 * Removed EOL Fedora versions (`32`, `33`, `34`).
 * Added current Fedora versions (`36`, `37`).
 * Added next Fedora versions (`38`).
 * Added development Fedora version (`rawhide`).

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>